### PR TITLE
Update pylint requirement

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,4 +23,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-       flake8 . --select=E501,E701 --ignore=E
+       flake8 . --ignore=E


### PR DESCRIPTION
@georgebuzzell @kianooshhosseini Please integrate this PR to your main branch. :pray:  It updates the automatic GitHub pylint requirements.  Previously, we had it set to warn you when you didn't meet some of the flake8 requirements, but George recently decided that this was too distracting for data collection/analysis projects (as opposed to tool development, where it is more useful).  So, once you integrate this PR, you shouldn't get error messages when you push changes to the repo that don't adhere to flake8 (for example, you have some really long lines of code).  Let me know if you have any questions!